### PR TITLE
JFS-12 inherit stdout, stdin, and stderr

### DIFF
--- a/src/jfswatch.rs
+++ b/src/jfswatch.rs
@@ -95,14 +95,14 @@ impl JFSWatch {
 
     /// Executes the specified command
     fn run_command(&self) {
-        let mut cmd = Command::new(&self.cmd[0]);
-        cmd.args(&self.cmd[1..]);
-        cmd.stderr(std::process::Stdio::inherit());
-        cmd.stdout(std::process::Stdio::inherit());
-        cmd.stdin(std::process::Stdio::inherit());
-
         info!("$ {}", self.cmd.join(" "));
-        let status = cmd.status(); // executes the command
+
+        let status = Command::new(&self.cmd[0])
+            .args(&self.cmd[1..])
+            .stderr(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::inherit())
+            .stdin(std::process::Stdio::inherit())
+            .status();
 
         match status {
             Ok(status) => {

--- a/src/jfswatch.rs
+++ b/src/jfswatch.rs
@@ -95,22 +95,23 @@ impl JFSWatch {
 
     /// Executes the specified command
     fn run_command(&self) {
-        debug!("Running command: {}", self.cmd.join(" "));
-
         let mut cmd = Command::new(&self.cmd[0]);
         cmd.args(&self.cmd[1..]);
+        cmd.stderr(std::process::Stdio::inherit());
+        cmd.stdout(std::process::Stdio::inherit());
+        cmd.stdin(std::process::Stdio::inherit());
 
-        let output = cmd.output().unwrap();
-        trace!(
-            "stdout:\n{}---\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr),
-        );
-        debug!(
-            "$ {} => exited {}",
-            self.cmd.join(" "),
-            output.status.code().unwrap()
-        );
+        info!("$ {}", self.cmd.join(" "));
+        let status = cmd.status(); // executes the command
+
+        match status {
+            Ok(status) => {
+                info!("\n... Exited with status: {}", status);
+            }
+            Err(error) => {
+                error!("... Error running command: {}", error);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This will help with situations where we care about the output of the command. For example, when we run `cargo test` anytime a `.rs` file changes.

Closes #12 