### PR TITLE
JFS-16 advanced shelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ For example, each time `Cargo.toml` is modified, append the current date to a
 file called 'Cargo.toml_was_modified.txt' and print the $SHELL environment
 variable used to execute that command.
 
+Note the difference between running "echo $SHELL" and 'echo $SHELL'. When
+double quoted, the variable will be evaluated when the command is created
+before being sent to jfswatch. When single quoted, it's passed as a raw string.
+
 $ jfswatch \
     --exact Cargo.toml \
     'echo running command in $SHELL && echo $(date) >> Cargo.toml_was_modified.txt'

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ file called 'Cargo.toml_was_modified.txt' and print the $SHELL environment
 variable used to execute that command.
 
 Note the difference between running "echo $SHELL" and 'echo $SHELL'. When
-double quoted, the variable will be evaluated when the command is created
-before being sent to jfswatch. When single quoted, it's passed as a raw string.
+double quoted, $SHELL will be evaluated first and then passed into jfswatch.
+When single quoted, $SHELL passed as a raw string to jfswatch, which will be
+evaluated later when the command is run. This difference is reflected in the
+jfswatch logs.
 
 $ jfswatch \
     --exact Cargo.toml \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ resuming standard interval checks.
 The logging level can be changed by setting the `RUST_LOG` environment variable
 to one of: `trace`, `debug`, `info`, `warn`, `error`.
 
-# Example
+# Simple Example
 Run `cargo test` when any Rust file changes. Check for changes every 0.5
 seconds and sleep for 2.0 seconds after running the tests.
 
@@ -22,6 +22,18 @@ $ jfswatch \
     --glob '**/*.rs' \
     --exact Cargo.toml \
     cargo test
+
+# Full Shell Example
+When you want to use powerful shell features such as pipes (|), redirects (>),
+multiple commands (&&), or environment variables, you must quote your command.
+
+For example, each time `Cargo.toml` is modified, append the current date to a
+file called 'Cargo.toml_was_modified.txt' and print the $SHELL environment
+variable used to execute that command.
+
+$ jfswatch \
+    --exact Cargo.toml \
+    'echo running command in $SHELL && echo $(date) >> Cargo.toml_was_modified.txt'
 
 Usage: jfswatch [OPTIONS] <CMD>...
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,8 +31,10 @@ file called 'Cargo.toml_was_modified.txt' and print the $SHELL environment
 variable used to execute that command.
 
 Note the difference between running "echo $SHELL" and 'echo $SHELL'. When
-double quoted, the variable will be evaluated when the command is created
-before being sent to jfswatch. When single quoted, it's passed as a raw string.
+double quoted, $SHELL will be evaluated first and then passed into jfswatch.
+When single quoted, $SHELL passed as a raw string to jfswatch, which will be
+evaluated later when the command is run. This difference is reflected in the
+jfswatch logs.
 
 $ jfswatch \
     --exact Cargo.toml \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{ArgAction, Parser};
 
 #[derive(Debug, Parser)]
-#[command(author, long_about = None, about = r"
+#[command(author, long_about = None, about = r#"
 Run a command when watched files change. Files can be given as exact paths or
 basic glob patterns. The program will check for mtime, new file, or deleted
 file changes every `interval` seconds. If a change is detected, the program
@@ -30,10 +30,14 @@ For example, each time `Cargo.toml` is modified, append the current date to a
 file called 'Cargo.toml_was_modified.txt' and print the $SHELL environment
 variable used to execute that command.
 
+Note the difference between running "echo $SHELL" and 'echo $SHELL'. When
+double quoted, the variable will be evaluated when the command is created
+before being sent to jfswatch. When single quoted, it's passed as a raw string.
+
 $ jfswatch \
     --exact Cargo.toml \
     'echo running command in $SHELL && echo $(date) >> Cargo.toml_was_modified.txt'
-")]
+"#)]
 pub struct Cli {
     /// The exact file paths to watch
     #[arg(short, long, action = ArgAction::Append)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ resuming standard interval checks.
 The logging level can be changed by setting the `RUST_LOG` environment variable
 to one of: `trace`, `debug`, `info`, `warn`, `error`.
 
-# Example
+# Simple Example
 Run `cargo test` when any Rust file changes. Check for changes every 0.5
 seconds and sleep for 2.0 seconds after running the tests.
 
@@ -20,7 +20,20 @@ $ jfswatch \
     --sleep 2.0 \
     --glob '**/*.rs' \
     --exact Cargo.toml \
-    cargo test")]
+    cargo test
+
+# Full Shell Example
+When you want to use powerful shell features such as pipes (|), redirects (>),
+multiple commands (&&), or environment variables, you must quote your command.
+
+For example, each time `Cargo.toml` is modified, append the current date to a
+file called 'Cargo.toml_was_modified.txt' and print the $SHELL environment
+variable used to execute that command.
+
+$ jfswatch \
+    --exact Cargo.toml \
+    'echo running command in $SHELL && echo $(date) >> Cargo.toml_was_modified.txt'
+")]
 pub struct Cli {
     /// The exact file paths to watch
     #[arg(short, long, action = ArgAction::Append)]

--- a/src/jfswatch.rs
+++ b/src/jfswatch.rs
@@ -95,10 +95,13 @@ impl JFSWatch {
 
     /// Executes the specified command
     fn run_command(&self) {
-        info!("$ {}", self.cmd.join(" "));
+        let shell = std::env::var("SHELL").unwrap_or("sh".to_string());
+        let command = self.cmd.join(" ");
 
-        let status = Command::new(&self.cmd[0])
-            .args(&self.cmd[1..])
+        info!("$ {}", command);
+
+        let status = Command::new(&shell)
+            .args(["-c", &command])
             .stderr(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
             .stdin(std::process::Stdio::inherit())


### PR DESCRIPTION
Now you can quote your command and do fancy stuff like `"echo $SHELL >> current_shell.txt"`

Confirmed through manual testing that simple jfswatch commands still work properly without quoting. As well as complicated ones that require quoting.

Closes #16